### PR TITLE
include/grub/riscv64: modify efi_max_usable addr

### DIFF
--- a/include/grub/riscv64/efi/memory.h
+++ b/include/grub/riscv64/efi/memory.h
@@ -1,6 +1,6 @@
 #ifndef GRUB_MEMORY_CPU_HEADER
 #include <grub/efi/memory.h>
 
-#define GRUB_EFI_MAX_USABLE_ADDRESS 0xffffffffffffULL
+#define GRUB_EFI_MAX_USABLE_ADDRESS 0xffffffffULL
 
 #endif /* ! GRUB_MEMORY_CPU_HEADER */


### PR DESCRIPTION
This is a temporary solution for relocation overflow on a segmented memory layout.